### PR TITLE
permit user option for streamplot colorkey

### DIFF
--- a/R/streamplot.R
+++ b/R/streamplot.R
@@ -149,7 +149,7 @@ setMethod('streamplot',
             streamList <- streamList[order(slopeVals)]
 
             p <- levelplot(object, layers=1,
-                           margin=FALSE, colorkey=FALSE,
+                           margin=FALSE, #colorkey=FALSE,
                            par.settings=par.settings, ...) + 
                              layer(lapply(streamList, function(streamlet){
                                panel.points(streamlet$x, streamlet$y,


### PR DESCRIPTION
A small change to the streamplot method allows the user to chose to include a colorkey for the levelplot underneath the droplets/streamlets.  A short example below...

```
V = volcano/10
V = V - mean(V)
U = V[nrow(V):1,]

V = raster::raster(V)
U = raster::raster(U)
S = raster::stack(U,V)

P_with = rasterVis::streamplot(S,
    isField = 'dXY',
    par.settings = rasterVis::streamTheme(
        region = rev(RColorBrewer::brewer.pal(n=4, name= 'Greys')),
        symbol = hexbin::BTC(n=9,beg=20)),
    droplet = list(pc = 1),
    scales = list(draw = TRUE),
    colorkey = TRUE)
    
P_without = rasterVis::streamplot(S,
    isField = 'dXY',
    par.settings = rasterVis::streamTheme(
        region = rev(RColorBrewer::brewer.pal(n=4, name= 'Greys')),
        symbol = hexbin::BTC(n=9,beg=20)),
    droplet = list(pc = 1),
    scales = list(draw = TRUE),
    colorkey = FALSE)
    
print(P_without, more = TRUE, split = c(1,1,1,2))
print(P_with, more = FALSE, split = c(1,2,1,2)) 
```
![streamplot](https://cloud.githubusercontent.com/assets/5097791/21429348/56ccb5ae-c82c-11e6-9900-bd6a71f27e95.png)
