### PR TITLE
terra

### DIFF
--- a/R/gplot.R
+++ b/R/gplot.R
@@ -12,6 +12,11 @@ if (!isGeneric("gplot")) {
 
 
 .gplot <- function(x, ...)  {
+    if (!requireNamespace("ggplot2", quietly = TRUE))
+	{
+		stop("ggplot2 is required for the gplot method.")
+	}
+
 	coords <- xyFromCell(x, seq_len(ncell(x)))
 	dat <- stack(as.data.frame(values(x)))
 	names(dat) <- c('value', 'variable')
@@ -23,10 +28,6 @@ if (!isGeneric("gplot")) {
 
 setMethod("gplot", signature(x='Raster'), 
           function(x, maxpixels=50000, ...)  {
-              if (!requireNamespace("ggplot2", quietly = TRUE))
-			  {
-				stop("ggplot2 is required for the gplot method.")
-			  }
               x <- raster::sampleRegular(x, maxpixels, asRaster=TRUE)
 			  .gplot(x, ...)
           }
@@ -36,10 +37,6 @@ setMethod("gplot", signature(x='Raster'),
 
 setMethod("gplot", signature(x='SpatRaster'), 
           function(x, maxpixels=50000, ...)  {
-              if (!requireNamespace("ggplot2", quietly = TRUE))
-			  {
-				stop("ggplot2 is required for the gplot method.")
-			  }
               x <- terra::spatSample(x, maxpixels, "regular", as.raster=TRUE)
 			  .gplot(x, ...)
           }

--- a/R/gplot.R
+++ b/R/gplot.R
@@ -10,22 +10,38 @@ if (!isGeneric("gplot")) {
 		standardGeneric("gplot"))
 }	
 
+
+.gplot <- function(x, ...)  {
+	coords <- xyFromCell(x, seq_len(ncell(x)))
+	dat <- stack(as.data.frame(values(x)))
+	names(dat) <- c('value', 'variable')
+	dat <- cbind(coords, dat)
+	ggplot2::ggplot(ggplot2::aes(x=x, y=y),
+                                  data=dat, ...)
+}
+
+
 setMethod("gplot", signature(x='Raster'), 
           function(x, maxpixels=50000, ...)  {
-              if (requireNamespace("ggplot2", quietly = TRUE))
-              {
-                  nl <- nlayers(x)
-                  x <- sampleRegular(x, maxpixels, asRaster=TRUE)
-                  coords <- xyFromCell(x, seq_len(ncell(x)))
-                  ## Extract values 
-                  dat <- stack(as.data.frame(getValues(x)))
-                  names(dat) <- c('value', 'variable')
-                  
-                  dat <- cbind(coords, dat)
+              if (!requireNamespace("ggplot2", quietly = TRUE))
+			  {
+				stop("ggplot2 is required for the gplot method.")
+			  }
+              x <- raster::sampleRegular(x, maxpixels, asRaster=TRUE)
+			  .gplot(x, ...)
+          }
+          )
 
-                  ggplot2::ggplot(ggplot2::aes(x=x, y=y),
-                                  data=dat, ...)
-              } else stop("ggplot2 is required for the gplot method.")
+
+
+setMethod("gplot", signature(x='SpatRaster'), 
+          function(x, maxpixels=50000, ...)  {
+              if (!requireNamespace("ggplot2", quietly = TRUE))
+			  {
+				stop("ggplot2 is required for the gplot method.")
+			  }
+              x <- terra::spatSample(x, maxpixels, "regular", as.raster=TRUE)
+			  .gplot(x, ...)
           }
           )
 


### PR DESCRIPTION
Here is how rasterVis might support `SpatRaster` objects from `terra`. I used `gplot` because it is a very small function, making for an easy example.

```
library(rasterVis)
r <- raster(system.file("external/test.grd", package="raster"))
s <- stack(r, r*2)
names(s) <- c('meuse', 'meuse x 2')

library(ggplot2)
theme_set(theme_bw())
gplot(s) + geom_tile(aes(fill = value)) +
          facet_wrap(~ variable) +
          scale_fill_gradient(low = 'white', high = 'blue') +
          coord_equal()

# and with terra 
library(terra)
s <- rast(s)
theme_set(theme_bw())
gplot(s) + geom_tile(aes(fill = value)) +
          facet_wrap(~ variable) +
          scale_fill_gradient(low = 'white', high = 'blue') +
          coord_equal()
```