### PR TITLE
adding raster:: to faciliate terra/raster dependency reversal

### DIFF
--- a/R/interactRaster.R
+++ b/R/interactRaster.R
@@ -33,7 +33,7 @@ setMethod('identifyRaster', signature(object='Raster'),
                                       pch = pch, cex = cex, col = col,...)
             }
             trellis.unfocus()
-            if (values) return(suppressWarnings(extract(object, idx))) else return(idx)
+            if (values) return(suppressWarnings(raster::extract(object, idx))) else return(idx)
           }
           )
 

--- a/R/levelplot.R
+++ b/R/levelplot.R
@@ -74,9 +74,13 @@ setGeneric('levelplot')
 
     ##aspect and scales(from sp::spplot.grid,
     ##sp::longlat.scales, sp::mapasp)
-    xlim=c(xmin(bb), xmax(bb))
-    ylim=c(ymin(bb), ymax(bb))
-
+    if (inherits(bb, "Extent")) {
+		xlim=c(raster::xmin(bb), raster::xmax(bb))
+		ylim=c(raster::ymin(bb), raster::ymax(bb))
+	} else {
+		xlim=c(terra::xmin(bb), terra::xmax(bb))
+		ylim=c(terra::ymin(bb), terra::ymax(bb))	
+	}
     if (isTRUE(isLonLat)){
 
         aspect=(diff(ylim)/diff(xlim))/cos((mean(ylim) * pi)/180)

--- a/R/streamplot.R
+++ b/R/streamplot.R
@@ -107,7 +107,7 @@ setMethod('streamplot',
               crdsNoise <- cbind(jitter(crds[,1]), jitter(crds[,2]))
               ## "Grid" of droplets
               texture <- SpatialPointsDataFrame(crdsNoise,
-                                                data.frame(extract(field, crdsNoise)))
+                                                data.frame(raster::extract(field, crdsNoise)))
               pts <- data.frame(t(coordinates(texture)))
               npts <- length(texture)
 

--- a/R/vectorplot.R
+++ b/R/vectorplot.R
@@ -50,8 +50,8 @@ sa2xy <- function(sa, dXY = FALSE,
     ## Returns a data.frame for panel.arrows
     dx <- getValues(dx) * aspX
     dy <- getValues(dy) * aspY
-    x <- getValues(init(sa, v='x'))
-    y <- getValues(init(sa, v='y'))
+    x <- getValues(raster::init(sa, fun='x'))
+    y <- getValues(raster::init(sa, fun='y'))
     data.frame(x, y, dx, dy)
 }
 

--- a/R/xyLayer.R
+++ b/R/xyLayer.R
@@ -15,8 +15,8 @@ xyLayer <- function(object, dirXY=y, vector = TRUE, maxpixels){
                                  size = maxpixels,
                                  as.raster = TRUE)
     }
-    y <- init(object, fun='y')
-    x <- init(object, fun='x')
+    y <- raster::init(object, fun='y')
+    x <- raster::init(object, fun='x')
     isLanguage <- try(is.language(dirXY), silent=TRUE)
     if (class(isLanguage)=='try-error' || !isLanguage)
         dirXY <- substitute(dirXY)

--- a/man/levelplot-methods.Rd
+++ b/man/levelplot-methods.Rd
@@ -454,7 +454,7 @@ r2[] = 3
 r2[51:100] = 1
 r2[3:6, 1:5] = 5
 
-r3 <- init(r, function(n)sample(c(1, 3, 5), n, replace=TRUE))
+r3 <- raster::init(r, function(n)sample(c(1, 3, 5), n, replace=TRUE))
 
 ## Multilayer categorical Raster* are displayed only if their RATs are the same
 levels(r2) <- levels(r3) <- levels(r)

--- a/man/vectorplot.Rd
+++ b/man/vectorplot.Rd
@@ -210,8 +210,8 @@ vectorplot(r1, region = FALSE,
 
 ## A vector field defined with horizontal and vertical components
 u <- v <- raster(xmn=0, xmx=2, ymn=0, ymx=2, ncol=1e3, nrow=1e3)
-x <- init(u, v='x')
-y <- init(u, v='y')
+x <- raster::init(u, fun='x')
+y <- raster::init(u, fun='y')
 u <- y * cos(x)
 v <- y * sin(x) 
 field <- stack(u, v)


### PR DESCRIPTION
I am switching the dependency between terra and raster. That is, I am making raster dependent on terra. The reason for the dependency is to avoid name clashes. This is a tricky operation as packages cannot be dependent on each other. So there will be a messy (but hopefully very short) transition period where terra is no longer dependent on raster, and raster not dependent on terra -- leading to name clashes. The proposed changes add "raster::" to some methods such that at least all the examples (R CMD check) still work. 

The reason for the switch is that be able methods from rgeos and rgdal that will be retired in the not so far future. Although I had this in mind irrespective of that. In my view, terra is the future and it should not depend on an old package.

