### PR TITLE
`levelplot()`: use `terra::cats()`

### DIFF
--- a/R/levelplot.R
+++ b/R/levelplot.R
@@ -478,7 +478,7 @@ setMethod('levelplot',
               }
 
               if (isFactor) {
-                  rat <- terra::levels(object)
+                  rat <- terra::cats(object)
                   ## It works correctly only if all the layers
                   ## share the same RAT
                   if (length(rat)>1 && any(!duplicated(rat)[-1])){


### PR DESCRIPTION
Hello. Thank you for the excellent package. 

I recently have been converting raster code to use terra and noticed some issues / changes in `terra::levels()` v.s. `terra::cats()`. `levels()` is a list of vectors containing the levels (no column names/ID), whereas `cats()` has (list of) ID, labels, colors, and other categories in data.frames (the RAT).

Fixes `Error in x@ptr$replaceValues(from, to, -1, opt): Not compatible with requested type: [type=NULL; target=double].` when plotting a categorical SpatRaster with `levelplot()`.


### Before

``` r
library(spDataLarge)
library(terra)
#> terra 1.5.19
library(rasterVis)
#> Loading required package: lattice

r1 <- spDataLarge::nlcd # 8 category National Land Cover Dataset
t1 <- terra::rast(r1)

rasterVis::levelplot(r1, att=2)
```

![](https://i.imgur.com/3pdjW7t.png)

``` r
rasterVis::levelplot(t1, att=2)
#> Error in x@ptr$replaceValues(from, to, -1, opt): Not compatible with requested type: [type=NULL; target=double].
```

### After

``` r
library(spDataLarge)
library(terra)
#> terra 1.5.19
library(rasterVis)
#> Loading required package: lattice

r1 <- spDataLarge::nlcd # 8 category National Land Cover Dataset
t1 <- terra::rast(r1)

rasterVis::levelplot(r1, att=2)
```

![](https://i.imgur.com/soe44lB.png)

``` r
rasterVis::levelplot(t1, att=2)
```

![](https://i.imgur.com/z9Fwkri.png)
