### PR TITLE
Replace rgl.cur() with cur3d()

### DIFF
--- a/R/plot3d.R
+++ b/R/plot3d.R
@@ -51,7 +51,7 @@ setMethod("plot3D", signature(x='RasterLayer'),
                       color <- level.colors(Zcol, at=at, col.regions=col)
                   }
                   ## Open a device only if there is none active
-                  if (rgl::rgl.cur() == 0) rgl::open3d()
+                  if (rgl::cur3d() == 0) rgl::open3d()
                   
                   if (background==min(Zcol)) {
                       trans <- Zcol


### PR DESCRIPTION
An upcoming release of `rgl` will deprecated `rgl.cur`.  This change should make no change to behavior, but will prevent a future warning/error.  For more details, see  https://github.com/dmurdoch/rgl/blob/deprecated/vignettes/deprecation.Rmd